### PR TITLE
Support iPhone 17e, iPad Air (M4), MacBook Air (M5), MacBook Neo, and MacBook Pro (M5 Pro/Max)

### DIFF
--- a/Sources/DeviceHardware/MacDeviceHardware.swift
+++ b/Sources/DeviceHardware/MacDeviceHardware.swift
@@ -49,6 +49,10 @@ public class MacDeviceHardware: DeviceHardware {
     // MARK: - Model Identifier
     enum ModelIdentifier: String {
         // MARK: MacBook Air
+        /// MacBook Air (13-inch, M5, 2026)
+        case Mac17_3 = "Mac17,3"
+        /// MacBook Air (15-inch, M5, 2026)
+        case Mac17_4 = "Mac17,4"
         /// MacBook Air (13-inch, M4, 2025)
         case Mac16_12 = "Mac16,12"
         /// MacBook Air (15-inch, M4, 2025)
@@ -79,6 +83,14 @@ public class MacDeviceHardware: DeviceHardware {
         case MacBookAir6_1 = "MacBookAir6,1"
 
         // MARK: MacBook Pro
+        /// MacBook Pro (14-inch, 2026) / M5 Pro
+        case Mac17_9 = "Mac17,9"
+        /// MacBook Pro (14-inch, 2026) / M5 Max
+        case Mac17_7 = "Mac17,7"
+        /// MacBook Pro (16-inch, 2026) / M5 Pro
+        case Mac17_8 = "Mac17,8"
+        /// MacBook Pro (16-inch, 2026) / M5 Max
+        case Mac17_6 = "Mac17,6"
         /// MacBook Pro (M5, 2025)  // 2025年10月発売モデル
         case Mac17_2 = "Mac17,2"
         /// MacBook Pro (14-inch, 2024) / M4
@@ -157,6 +169,10 @@ public class MacDeviceHardware: DeviceHardware {
         /// MacBook Pro (Retina, 13-inch, Mid 2014), MacBook Pro (Retina, 13-inch, Late 2013)
         case MacBookPro11_1 = "MacBookPro11,1"
         
+        // MARK: MacBook
+        /// MacBook (2026) / A18 Pro
+        case Mac17_5 = "Mac17,5"
+
         // MARK: MacBook (12-inch)
         /// MacBook (Retina, 12-inch, 2017)
         case MacBook10_1 = "MacBook10,1"
@@ -281,8 +297,11 @@ public class MacDeviceHardware: DeviceHardware {
            /// M4, M4 Pro, M4 Max
            case .Mac16_1, .Mac16_2, .Mac16_3, .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_10, .Mac16_15, .Mac16_12, .Mac16_13:
                return "16-core"
-           /// M5
-           case .Mac17_2:
+           /// M5, M5 Pro, M5 Max
+           case .Mac17_2, .Mac17_3, .Mac17_4, .Mac17_6, .Mac17_7, .Mac17_8, .Mac17_9:
+               return "16-core"
+           /// A18 Pro (MacBook Neo)
+           case .Mac17_5:
                return "16-core"
            default:
                return "None"
@@ -293,6 +312,10 @@ public class MacDeviceHardware: DeviceHardware {
        func modelName() -> String {
            switch self {
            // MARK: MacBook Air
+           case .Mac17_3:
+               return "MacBook Air (13-inch, M5, 2026)"
+           case .Mac17_4:
+               return "MacBook Air (15-inch, M5, 2026)"
            case .Mac16_12:
                return "MacBook Air (13-inch, M4, 2025)"
            case .Mac16_13:
@@ -326,6 +349,10 @@ public class MacDeviceHardware: DeviceHardware {
                return "MacBook Air (11-inch, Early 2014) / (11-inch, Mid 2013)"
            
            // MARK: MacBook Pro
+           case .Mac17_7, .Mac17_9:
+               return "MacBook Pro (14-inch, 2026)"
+           case .Mac17_6, .Mac17_8:
+               return "MacBook Pro (16-inch, 2026)"
            case .Mac17_2:
                return "MacBook Pro (14-inch, 2025)"
            case .Mac16_1, .Mac16_6, .Mac16_8:
@@ -387,6 +414,10 @@ public class MacDeviceHardware: DeviceHardware {
                /// Need some decision processing
                return "MacBook Pro (Retina, 13-inch, Mid 2014) / (Retina, 13-inch, Late 2013)"
                
+           // MARK: MacBook
+           case .Mac17_5:
+               return "MacBook Neo"
+
            // MARK: MacBook (12-inch)
            case .MacBook10_1:
                return "MacBook (Retina, 12-inch, 2017)"
@@ -674,8 +705,14 @@ public extension MacDeviceHardware {
             case .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_15:
                 return "4.51GHz \(core)-core"
             /// M5
-            case .Mac17_2:
+            case .Mac17_2, .Mac17_3, .Mac17_4:
                 return "4.61GHz \(core)-core"
+            /// M5 Pro, M5 Max
+            case .Mac17_6, .Mac17_7, .Mac17_8, .Mac17_9:
+                return "4.61GHz \(core)-core"
+            /// A18 Pro (MacBook Neo)
+            case .Mac17_5:
+                return "4.05GHz \(core)-core"
             default:
                 return nil
             }

--- a/Sources/DeviceHardware/UIDeviceHardware.swift
+++ b/Sources/DeviceHardware/UIDeviceHardware.swift
@@ -288,6 +288,8 @@ public class UIDeviceHardware: DeviceHardware {
         case iPhone18_2 = "iPhone18,2"
         /// iPhone Air
         case iPhone18_4 = "iPhone18,4"
+        /// iPhone 17e
+        case iPhone18_5 = "iPhone18,5"
         
         // MARK: iPad
         /// iPad
@@ -465,6 +467,14 @@ public class UIDeviceHardware: DeviceHardware {
         /// iPad mini (A17 Pro)
         case iPad16_1 = "iPad16,1"
         case iPad16_2 = "iPad16,2"
+        /// iPad Air 11-inch (M4) Wi-Fi
+        case iPad16_8 = "iPad16,8"
+        /// iPad Air 11-inch (M4) Wi-Fi + Cellular
+        case iPad16_9 = "iPad16,9"
+        /// iPad Air 13-inch (M4) Wi-Fi
+        case iPad16_10 = "iPad16,10"
+        /// iPad Air 13-inch (M4) Wi-Fi + Cellular
+        case iPad16_11 = "iPad16,11"
         /// iPad Pro 11-inch (M5, 2025) Wi-Fi
         case iPad17_1 = "iPad17,1"
         /// iPad Pro 11-inch (M5, 2025) Wi-Fi + Cellular
@@ -671,6 +681,12 @@ public class UIDeviceHardware: DeviceHardware {
                 return "iPhone 17"
             case .iPhone18_4:
                 return "iPhone Air"
+            case .iPhone18_5:
+                return "iPhone 17e"
+            case .iPad16_8, .iPad16_9:
+                return "iPad Air (M4) (11-inch)"
+            case .iPad16_10, .iPad16_11:
+                return "iPad Air (M4) (13-inch)"
             case .iPad17_1, .iPad17_2:
                 return "iPad Pro (M5) (11-inch)"
             case .iPad17_3, .iPad17_4:
@@ -765,8 +781,8 @@ public class UIDeviceHardware: DeviceHardware {
             /// iPhone 15 Pro/15 Pro Max
             case .iPhone16_1, .iPhone16_2, .iPad16_1, .iPad16_2:
                 return "Apple A17 Pro"
-            /// iPad Pro (M4)
-            case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6:
+            /// iPad Pro (M4), iPad Air (M4)
+            case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6, .iPad16_8, .iPad16_9, .iPad16_10, .iPad16_11:
                 return "Apple M4"
             /// iPhone 16/16 Plus
             case .iPhone17_3, .iPhone17_4, .iPhone17_5:
@@ -774,8 +790,8 @@ public class UIDeviceHardware: DeviceHardware {
             /// iPhone 16 Pro/16 Pro Max
             case .iPhone17_1, .iPhone17_2:
                 return "Apple A18 Pro"
-            /// iPhone 17
-            case .iPhone18_3:
+            /// iPhone 17, iPhone 17e
+            case .iPhone18_3, .iPhone18_5:
                 return "Apple A19"
             /// iPhone 17 Pro/17 Pro Max, iPhone Aie
             case .iPhone18_4, .iPhone18_2, .iPhone18_1:
@@ -905,13 +921,17 @@ public class UIDeviceHardware: DeviceHardware {
             /// Apple M4
             case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6:
                 return "4.4GHz 10-core"
+            /// iPad Air (M4)
+            /// Apple M4
+            case .iPad16_8, .iPad16_9, .iPad16_10, .iPad16_11:
+                return "4.4GHz 8-core"
             /// iPhone 16/16Plus, iPhone 16Pro/16 Pro Max
             /// Apple A18, Apple A18 Pro
             case .iPhone17_1, .iPhone17_2, .iPhone17_3, .iPhone17_4, .iPhone17_5:
                 return "4.05GHz 6-core"
-            /// iPhone 17, iPhone 17 Pro/17 Pro Max, iPhone Air
+            /// iPhone 17, iPhone 17e, iPhone 17 Pro/17 Pro Max, iPhone Air
             /// Apple A19, Apple A19 Pro
-            case .iPhone18_1, .iPhone18_2, .iPhone18_3, .iPhone18_4:
+            case .iPhone18_1, .iPhone18_2, .iPhone18_3, .iPhone18_4, .iPhone18_5:
                 return "4.26GHz 6-core"
             /// iPad Pro (M5)
             case .iPad17_1, .iPad17_2, .iPad17_3, .iPad17_4:
@@ -1025,6 +1045,10 @@ public class UIDeviceHardware: DeviceHardware {
             /// Apple M4
             case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6:
                 return "10-core"
+            /// iPad Air (M4)
+            /// Apple M4
+            case .iPad16_8, .iPad16_9, .iPad16_10, .iPad16_11:
+                return "9-core"
             /// iPhone 16/16 Plus
             /// Apple A18
             case .iPhone17_3, .iPhone17_4:
@@ -1033,9 +1057,9 @@ public class UIDeviceHardware: DeviceHardware {
             /// Apple A18 Pro
             case .iPhone17_1, .iPhone17_2:
                 return "6-core"
-            /// iPhone 16e
-            /// Apple A18
-            case .iPhone17_5:
+            /// iPhone 16e, iPhone 17e
+            /// Apple A18, Apple A19
+            case .iPhone17_5, .iPhone18_5:
                 return "4-core"
             /// iPhone 17
             /// Apple A19
@@ -1106,19 +1130,19 @@ public class UIDeviceHardware: DeviceHardware {
             /// 35 TOPS
             case .iPhone16_1, .iPhone16_2, .iPad16_1, .iPad16_2:
                 return "16-core"
-            /// iPad Pro M4
+            /// iPad Pro M4, iPad Air (M4)
             /// Apple M4
             /// 38 TOPS
-            case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6:
+            case .iPad16_3, .iPad16_4, .iPad16_5, .iPad16_6, .iPad16_8, .iPad16_9, .iPad16_10, .iPad16_11:
                 return "16-core"
             /// iPhone 16/16 Plus, iPhone 16 Pro/16 Pro Max
             /// Apple A18, Apple A18 Pro
             /// 35 TOPS
             case .iPhone17_1, .iPhone17_2, .iPhone17_3, .iPhone17_4, .iPhone17_5:
                 return "16-core"
-            /// iPhone 17, iPhone 17 Pro/17 Pro Max, iPhone Air
+            /// iPhone 17, iPhone 17e, iPhone 17 Pro/17 Pro Max, iPhone Air
             /// Apple A19, Apple A19 Pro
-            case .iPhone18_1, .iPhone18_2, .iPhone18_3, .iPhone18_4:
+            case .iPhone18_1, .iPhone18_2, .iPhone18_3, .iPhone18_4, .iPhone18_5:
                 return "16-core"
             /// iPad Pro (M5)
             case .iPad17_1, .iPad17_2, .iPad17_3, .iPad17_4:


### PR DESCRIPTION
## Summary
Closes #48.

### iOS (`UIDeviceHardware.swift`)
- iPhone 17e (`iPhone18,5`) — Apple A19 / 6-core CPU / 4-core GPU / 16-core Neural Engine / Dynamic Island なし
- iPad Air (M4) 11-inch (`iPad16,8` / `iPad16,9`) / 13-inch (`iPad16,10` / `iPad16,11`) — Apple M4 / 8-core CPU / 9-core GPU / 16-core Neural Engine

### macOS (`MacDeviceHardware.swift`)
- MacBook Air 13-inch / 15-inch (M5, 2026) — `Mac17,3` / `Mac17,4`
- MacBook Neo (`Mac17,5`) — Apple A18 Pro 搭載
- MacBook Pro 14-inch / 16-inch (M5 Pro / M5 Max, 2026) — `Mac17,6` – `Mac17,9`

### Notes
- M5 Pro / M5 Max のクロックは公開情報を確認できなかったため、暫定で M5 と同じ `4.61GHz` を割り当てています。確定値が分かれば差分で更新してください。

## Test plan
- [x] `swift build`
- [ ] iPhone 17e 実機で `modelName` / `processorName` / `cpu` / `gpu` / `neuralEngine` を確認
- [ ] iPad Air (M4) 実機で同上
- [ ] MacBook Air (M5) / MacBook Neo / MacBook Pro (M5 Pro/Max) 実機で同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)