### PR TITLE
Fix iPad Pro M2 model identifier matching

### DIFF
--- a/Sources/DeviceHardware/UIDeviceHardware.swift
+++ b/Sources/DeviceHardware/UIDeviceHardware.swift
@@ -438,16 +438,14 @@ public class UIDeviceHardware: DeviceHardware {
         /// iPad (10th generation)
         case iPad13_18 = "iPad13,18"
         case iPad13_19 = "iPad13,19"
-        /// iPad Pro 11-inch (4th generation)
-        case iPad14_3_A = "iPad14,3-A"
-        case iPad14_3_B = "iPad14,3-B"
-        case iPad14_4_A = "iPad14,4-A"
-        case iPad14_4_B = "iPad14,4-B"
-        /// iPad Pro 12.9-inch (6th generation)
-        case iPad14_5_A = "iPad14,5-A"
-        case iPad14_5_B = "iPad14,5-B"
-        case iPad14_6_A = "iPad14,6-A"
-        case iPad14_6_B = "iPad14,6-B"
+        /// iPad Pro 11-inch (4th generation) Wi-Fi
+        case iPad14_3 = "iPad14,3"
+        /// iPad Pro 11-inch (4th generation) Wi-Fi + Cellular
+        case iPad14_4 = "iPad14,4"
+        /// iPad Pro 12.9-inch (6th generation) Wi-Fi
+        case iPad14_5 = "iPad14,5"
+        /// iPad Pro 12.9-inch (6th generation) Wi-Fi + Cellular
+        case iPad14_6 = "iPad14,6"
         /// iPad Air 11-inch (6th generation) Wi-Fi
         case iPad14_8 = "iPad14,8"
         /// iPad Air 11-inch (6th generation) Wi-Fi + Cellular
@@ -653,9 +651,9 @@ public class UIDeviceHardware: DeviceHardware {
                 return "iPhone 14 Pro Max"
             case .iPad13_18, .iPad13_19:
                 return "iPad (10th generation)"
-            case .iPad14_3_A, .iPad14_3_B, .iPad14_4_A, .iPad14_4_B:
+            case .iPad14_3, .iPad14_4:
                 return "iPad Pro (11-inch) (4th generation)"
-            case .iPad14_5_A, .iPad14_5_B, .iPad14_6_A, .iPad14_6_B:
+            case .iPad14_5, .iPad14_6:
                 return "iPad Pro (12.9-inch) (6th generation)"
             case .iPhone15_4:
                 return "iPhone 15"
@@ -794,7 +792,7 @@ public class UIDeviceHardware: DeviceHardware {
             case .iPhone15_2, .iPhone15_3, .iPhone15_4, .iPhone15_5, .iPad15_7, .iPad15_8:
                 return "Apple A16 Bionic"
             /// iPad Pro (6th)
-            case .iPad14_3_A, .iPad14_3_B, .iPad14_4_A, .iPad14_4_B, .iPad14_5_A, .iPad14_5_B, .iPad14_6_A, .iPad14_6_B, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
+            case .iPad14_3, .iPad14_4, .iPad14_5, .iPad14_6, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
                 return "Apple M2"
             /// iPad Air (M3)
             case .iPad15_3, .iPad15_4, .iPad15_5, .iPad15_6:
@@ -936,7 +934,7 @@ public class UIDeviceHardware: DeviceHardware {
                 return "3.46GHz 5-core"
             /// iPad Pro (6th)
             /// Apple M2
-            case .iPad14_3_A, .iPad14_3_B, .iPad14_4_A, .iPad14_4_B, .iPad14_5_A, .iPad14_5_B, .iPad14_6_A, .iPad14_6_B, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
+            case .iPad14_3, .iPad14_4, .iPad14_5, .iPad14_6, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
                 return "3.49GHz 6-core"
             /// iPad Air (M3)
             /// Apple M3
@@ -1068,7 +1066,7 @@ public class UIDeviceHardware: DeviceHardware {
                 return "4-core"
             /// iPad Pro (6th)
             /// Apple M2
-            case .iPad14_3_A, .iPad14_3_B, .iPad14_4_A, .iPad14_4_B, .iPad14_5_A, .iPad14_5_B, .iPad14_6_A, .iPad14_6_B, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
+            case .iPad14_3, .iPad14_4, .iPad14_5, .iPad14_6, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
                 return "10-core"
             /// iPad Air (M3)
             /// Apple M3
@@ -1160,7 +1158,7 @@ public class UIDeviceHardware: DeviceHardware {
             /// iPad Pro (6th)
             /// Apple M2
             /// 15.8 TOPS
-            case .iPad14_3_A, .iPad14_3_B, .iPad14_4_A, .iPad14_4_B, .iPad14_5_A, .iPad14_5_B, .iPad14_6_A, .iPad14_6_B, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
+            case .iPad14_3, .iPad14_4, .iPad14_5, .iPad14_6, .iPad14_8, .iPad14_9, .iPad14_10, .iPad14_11:
                 return "16-core"
             /// iPad Air (M3)
             /// Apple M3


### PR DESCRIPTION
## Summary
M2 iPad Pro (4th-gen 11-inch / 6th-gen 12.9-inch) を実機で使うと `modelName` が `\"Unknown\"` になっていたバグの修正。

### 原因
`UIDeviceHardware.ModelIdentifier` で当該機種は以下のように 8 ケース定義されていた:

\`\`\`swift
case iPad14_3_A = \"iPad14,3-A\"
case iPad14_3_B = \"iPad14,3-B\"
case iPad14_4_A = \"iPad14,4-A\"
…
\`\`\`

しかし `sysctlbyname(\"hw.machine\")` が返す値はサフィックスなしの素の `\"iPad14,3\"` 等。`ModelIdentifier(rawValue: \"iPad14,3\")` は \`-A\` / \`-B\` 付き rawValue にマッチせず常に nil を返すため、`getModelName()` が nil → 公開プロパティ `modelName` が `\"Unknown\"` にフォールバックしていた。

### 根拠
- adamawolf gist (#38 で参照されている iPhone/iPad モデル識別子一覧) はサフィックスなしの `\"iPad14,3 : iPad Pro (11-inch, WiFi) (4th generation)\"` 等を記載
- ipsw.me API も同じく `\"iPad14,3\"` (サフィックスなし) を返す
- DeviceKit (Swift で最も使われている端末識別ライブラリ) も `case \"iPad14,3\", \"iPad14,4\": return iPadPro11Inch4` でサフィックスなしリテラルにマッチさせている
- 本リポジトリには文字列を加工する処理が存在しない (`getModelIdentifier` は `String(cString:)` でカーネル文字列をそのまま返すのみ)

### 変更内容
8 ケース → 4 ケースに削減し、Wi-Fi / Wi-Fi + Cellular で分割。

| 旧 rawValue | 新 rawValue | バリアント |
|---|---|---|
| \"iPad14,3-A\" / \"iPad14,3-B\" | \"iPad14,3\" | Wi-Fi (4th gen 11-inch) |
| \"iPad14,4-A\" / \"iPad14,4-B\" | \"iPad14,4\" | Wi-Fi + Cellular (4th gen 11-inch) |
| \"iPad14,5-A\" / \"iPad14,5-B\" | \"iPad14,5\" | Wi-Fi (6th gen 12.9-inch) |
| \"iPad14,6-A\" / \"iPad14,6-B\" | \"iPad14,6\" | Wi-Fi + Cellular (6th gen 12.9-inch) |

`processorName()` / `cpu()` / `gpu()` / `neuralEngine()` で参照している箇所も併せて 4 ケース化。

## Test plan
- [x] \`swift build\`
- [ ] M2 iPad Pro 実機で \`modelName\` が \"Unknown\" ではなく正しい名称を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)