### PR TITLE
Support iPad (Wi-Fi + 3G), Mac Studio (2025), and Mac mini (Mac16,11)

### DIFF
--- a/Sources/DeviceHardware/MacDeviceHardware.swift
+++ b/Sources/DeviceHardware/MacDeviceHardware.swift
@@ -190,6 +190,8 @@ public class MacDeviceHardware: DeviceHardware {
         case MacPro6_1 = "MacPro6,1"
 
         // MARK: Mac mini
+        /// Mac mini (2024)
+        case Mac16_11 = "Mac16,11"
         /// Mac mini (2024) / M4
         case Mac16_10 = "Mac16,10"
         /// Mac mini (2024) / M4 Pro
@@ -254,6 +256,10 @@ public class MacDeviceHardware: DeviceHardware {
         case iMac13_1 = "iMac13,1"
         
         // MARK: Mac Studio
+        /// Mac Studio (2025) / M3 Ultra
+        case Mac15_14 = "Mac15,14"
+        /// Mac Studio (2025) / M4 Max
+        case Mac16_9 = "Mac16,9"
         /// Mac Studio (2023) / M2 Max
         case Mac14_13 = "Mac14,13"
         /// Mac Studio (2023) / M2 Ultra
@@ -294,8 +300,11 @@ public class MacDeviceHardware: DeviceHardware {
            /// M3, M3 Pro, M3 Max
            case .Mac15_3, .Mac15_4, .Mac15_5, .Mac15_6, .Mac15_7, .Mac15_8, .Mac15_9, .Mac15_10, .Mac15_11, .Mac15_12, .Mac15_13:
                return "16-core"
+           /// M3 Ultra
+           case .Mac15_14:
+               return "32-core"
            /// M4, M4 Pro, M4 Max
-           case .Mac16_1, .Mac16_2, .Mac16_3, .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_10, .Mac16_15, .Mac16_12, .Mac16_13:
+           case .Mac16_1, .Mac16_2, .Mac16_3, .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_9, .Mac16_10, .Mac16_11, .Mac16_15, .Mac16_12, .Mac16_13:
                return "16-core"
            /// M5, M5 Pro, M5 Max
            case .Mac17_2, .Mac17_3, .Mac17_4, .Mac17_6, .Mac17_7, .Mac17_8, .Mac17_9:
@@ -435,7 +444,7 @@ public class MacDeviceHardware: DeviceHardware {
                return "Mac Pro (Late 2013)"
                
            // MARK: Mac mini
-           case .Mac16_15, .Mac16_10:
+           case .Mac16_15, .Mac16_10, .Mac16_11:
                return "Mac mini (2024)"
            case .Mac14_3, .Mac14_12:
                return "Mac mini (2023)"
@@ -494,6 +503,8 @@ public class MacDeviceHardware: DeviceHardware {
                return "iMac (21.5-inch, Late 2012)"
                
            // MARK: Mac Studio
+           case .Mac15_14, .Mac16_9:
+               return "Mac Studio (2025)"
            case .Mac14_13, .Mac14_14:
                return "Mac Studio (2023)"
            case .Mac13_1, .Mac13_2:
@@ -696,13 +707,13 @@ public extension MacDeviceHardware {
             case .Mac14_2, .Mac14_7, .Mac14_3, .Mac14_15, .Mac14_5, .Mac14_6, .Mac14_9, .Mac14_10, .Mac14_12, .Mac14_13, .Mac14_14, .Mac14_8:
                 return "3.49GHz \(core)-core"
             /// M3 family
-            case .Mac15_3, .Mac15_4, .Mac15_5, .Mac15_6, .Mac15_7, .Mac15_8, .Mac15_9, .Mac15_10, .Mac15_11, .Mac15_12, .Mac15_13:
+            case .Mac15_3, .Mac15_4, .Mac15_5, .Mac15_6, .Mac15_7, .Mac15_8, .Mac15_9, .Mac15_10, .Mac15_11, .Mac15_12, .Mac15_13, .Mac15_14:
                 return "4.05GHz \(core)-core"
             /// M4
             case .Mac16_1, .Mac16_2, .Mac16_3, .Mac16_10, .Mac16_12, .Mac16_13:
                 return "4.4GHz \(core)-core"
             /// M4 Pro, M4 Max
-            case .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_15:
+            case .Mac16_5, .Mac16_6, .Mac16_7, .Mac16_8, .Mac16_9, .Mac16_11, .Mac16_15:
                 return "4.51GHz \(core)-core"
             /// M5
             case .Mac17_2, .Mac17_3, .Mac17_4:

--- a/Sources/DeviceHardware/UIDeviceHardware.swift
+++ b/Sources/DeviceHardware/UIDeviceHardware.swift
@@ -294,6 +294,8 @@ public class UIDeviceHardware: DeviceHardware {
         // MARK: iPad
         /// iPad
         case iPad1_1 = "iPad1,1"
+        /// iPad Wi-Fi + 3G
+        case iPad1_2 = "iPad1,2"
         /// iPad 2
         case iPad2_1 = "iPad2,1"
         /// iPad 2 GSM
@@ -573,7 +575,7 @@ public class UIDeviceHardware: DeviceHardware {
                 return "iPhone 12 Pro"
             case .iPhone13_4:
                 return "iPhone 12 Pro Max"
-            case .iPad1_1:
+            case .iPad1_1, .iPad1_2:
                 return "iPad (1st generation)"
             case .iPad2_1, .iPad2_4, .iPad2_2, .iPad2_3:
                 return "iPad 2"
@@ -731,7 +733,7 @@ public class UIDeviceHardware: DeviceHardware {
             case .iPod3_1:
                 return "APL2298"
             /// iPhone 4, iPad (1st), iPod touch (4th)
-            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1:
+            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1, .iPad1_2:
                 return "Apple A4"
             /// iPhone 4s, iPad 2, iPod touch (5th), iPad mini (1st)
             case .iPhone4_1, .iPod5_1, .iPad2_5, .iPad2_6, .iPad2_7, .iPad2_1, .iPad2_2, .iPad2_3, .iPad2_4:
@@ -844,7 +846,7 @@ public class UIDeviceHardware: DeviceHardware {
                 return "800MHz 1-core"
             /// iPhone 4, iPad (1st), iPod touch (4th)
             /// Apple A4
-            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1:
+            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1, .iPad1_2:
                 return "1.0GHz 1-core"
             /// iPhone 4s, iPad 2, iPod touch (5th), iPad mini (1st)
             /// Apple A5
@@ -987,7 +989,7 @@ public class UIDeviceHardware: DeviceHardware {
             case .iPod3_1:
                 return "PowerVR SGX535"
             /// iPhone 4, iPad (1st), iPod touch (4th)
-            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1:
+            case .iPod4_1, .iPhone3_1, .iPhone3_2, .iPhone3_3, .iPad1_1, .iPad1_2:
                 return "PowerVR SGX535"
             /// iPhone 4s, iPad 2, iPod touch (5th), iPad mini (1st)
             case .iPhone4_1, .iPod5_1, .iPad2_5, .iPad2_6, .iPad2_7, .iPad2_1, .iPad2_2, .iPad2_3, .iPad2_4:


### PR DESCRIPTION
## Summary
未登録だった model identifier を追加。

### iOS (`UIDeviceHardware.swift`)
- `iPad1,2` — 初代 iPad Wi-Fi + 3G (2010)。Apple A4 / 1.0GHz 1-core / PowerVR SGX535、既存の `iPad1,1` (Wi-Fi のみ) と同一スペックなので各 switch でグルーピング。

### macOS (`MacDeviceHardware.swift`)
- `Mac15,14` — Mac Studio (2025) / M3 Ultra (Neural Engine 32-core, 4.05GHz)
- `Mac16,9` — Mac Studio (2025) / M4 Max (Neural Engine 16-core, 4.51GHz)
- `Mac16,11` — Mac mini (2024)。Apple サポートページ ([102852](https://support.apple.com/en-us/102852)) に Mac mini (2024) の Model Identifier として記載されている ID。コードベースの `Mac16,10` (M4) / `Mac16,15` (M4 Pro) と並立する形で M4 Pro 系列扱いで追加。

### スペック典拠
- Mac Studio: https://support.apple.com/en-us/102231
- Mac mini: https://support.apple.com/en-us/102852
- iPad (1st gen) はチップ・スペック共に既存の iPad1,1 と同一

## Test plan
- [x] `swift build`
- [ ] Mac Studio (2025) 実機で `modelName` / `processorName` / `cpu` / `gpu` / `neuralEngine` を確認
- [ ] Mac mini (2024) 実機で `modelIdentifier` が `Mac16,10` / `Mac16,11` / `Mac16,15` のどれを返すか確認
- [ ] (任意) 初代 iPad Wi-Fi + 3G 実機が手元にあれば動作確認

## Notes
- M3 Ultra / M4 Max のクロックは既存の M3 / M4 Pro/Max ファミリーの値 (`4.05GHz` / `4.51GHz`) を踏襲。確定値が分かれば差分で更新してください。
- `Mac16,11` が実際にどの SKU を指すかは実機確認が望ましい (ipsw.me API では M4 Pro となっている)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)